### PR TITLE
Maximum Number of Events that can be Attended

### DIFF
--- a/problems/1353.maximum-number-of-events-that-can-be-attended/README.md
+++ b/problems/1353.maximum-number-of-events-that-can-be-attended/README.md
@@ -1,0 +1,32 @@
+# 1353. Maximum Number of Events That Can Be Attended
+
+You are given an array of `events` where `events[i] = [startDayi, endDayi]`. Every event `i` starts at `startDayi` and ends at `endDayi`.
+
+You can attend an event `i` at any day `d` where `startTimei <= d <= endTimei`. You can only attend one event at any time `d`.
+
+Return _the maximum number of events you can attend_.
+
+**Example 1:**
+
+```bash
+Input: events = [[1,2],[2,3],[3,4]]
+Output: 3
+Explanation: You can attend all the three events.
+One way to attend them all is as shown.
+Attend the first event on day 1.
+Attend the second event on day 2.
+Attend the third event on day 3.
+```
+
+**Example 2:**
+
+```bash
+Input: events= [[1,2],[2,3],[3,4],[1,2]]
+Output: 4
+```
+
+**Constraints:**
+
+- `1 <= events.length <= 10^5`
+- `events[i].length == 2`
+- `1 <= startDayi <= endDayi <= 10^5`

--- a/problems/1353.maximum-number-of-events-that-can-be-attended/maximum-number-of-events-that-can-be-attended.js
+++ b/problems/1353.maximum-number-of-events-that-can-be-attended/maximum-number-of-events-that-can-be-attended.js
@@ -1,0 +1,47 @@
+/**
+ * @param {number[][]} events
+ * @return {number}
+ */
+class DSU {
+  constructor(n) {
+    this.parent = Array.from({ length: n + 2 }, (_, i) => i);
+  }
+
+  find(x) {
+    if (this.parent[x] !== x) {
+      this.parent[x] = this.find(this.parent[x]);
+    }
+    return this.parent[x];
+  }
+
+  union(x, y) {
+    const px = this.find(x);
+    const py = this.find(y);
+    this.parent[px] = py;
+  }
+}
+
+const maxEvents = function (events) {
+  events.sort((a, b) => a[1] - b[1]);
+
+  let maxDay = 0;
+  for (const [, e] of events) {
+    if (e > maxDay) {
+      maxDay = e;
+    }
+  }
+
+  const dsu = new DSU(maxDay);
+
+  let attended = 0;
+
+  for (const [s, e] of events) {
+    const day = dsu.find(s);
+    if (day <= e) {
+      attended++;
+      dsu.union(day, day + 1);
+    }
+  }
+
+  return attended;
+};


### PR DESCRIPTION
## Summary by Sourcery

Add JavaScript solution for LeetCode problem “Maximum Number of Events That Can Be Attended” using a DSU-based greedy approach and include the problem README with description, examples, and constraints.

New Features:
- Implement `maxEvents` function with a disjoint set union to select the maximum attendable events.
- Add README.md detailing the problem statement, examples, and constraints.